### PR TITLE
UseCase: 기사님의 택시 정보 등록 

### DIFF
--- a/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/DriverApi.kt
+++ b/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/DriverApi.kt
@@ -20,7 +20,7 @@ class DriverApi(
         driverTaxiRegistrationRequest.hasNoProblem()
 
         val registeredTaxiInfo = driverService.taxiInfoRegister(
-            DriverCommand.Register.of(
+            DriverCommand.Register(
                 driverId = driverId,
                 taxiNumber = driverTaxiRegistrationRequest.taxiNumber,
                 taxiType = driverTaxiRegistrationRequest.taxiType,

--- a/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/DriverApi.kt
+++ b/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/DriverApi.kt
@@ -1,0 +1,33 @@
+package com.plus.taxiapp.api.taxiDriver
+
+import com.plus.taxiapp.api.taxiDriver.request.DriverTaxiRegistrationRequest
+import com.plus.taxiapp.api.taxiDriver.response.DriverTaxiRegistrationResponse
+import com.plus.taxiapp.domain.taxiDriver.command.DriverCommand
+import com.plus.taxiapp.domain.taxiDriver.DriverService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping(value = ["/api/drivers/"], produces = ["application/json"])
+class DriverApi(
+    private val driverService: DriverService,
+) {
+    @PostMapping("/{driverId}/taxis")
+    fun taxiRegister(
+        @PathVariable driverId: String,
+        @RequestBody driverTaxiRegistrationRequest: DriverTaxiRegistrationRequest,
+    ): ResponseEntity<DriverTaxiRegistrationResponse> {
+        driverTaxiRegistrationRequest.hasNoProblem()
+
+        val registeredTaxiInfo = driverService.taxiInfoRegister(
+            DriverCommand.Register.of(
+                driverId = driverId,
+                taxiNumber = driverTaxiRegistrationRequest.taxiNumber,
+                taxiType = driverTaxiRegistrationRequest.taxiType,
+                taxiModel = driverTaxiRegistrationRequest.taxiModel,
+            )
+        )
+
+        return ResponseEntity.ok().body(DriverTaxiRegistrationResponse.create(registeredTaxiInfo))
+    }
+}

--- a/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/request/DriverTaxiRegistrationRequest.kt
+++ b/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/request/DriverTaxiRegistrationRequest.kt
@@ -1,0 +1,15 @@
+package com.plus.taxiapp.api.taxiDriver.request
+
+import com.plus.taxiapp.api.taxiDriver.request.policy.RequestCheckHelper
+import com.plus.taxiapp.domain.taxiDriver.DriverType
+
+
+data class DriverTaxiRegistrationRequest (
+    val taxiNumber: String,
+    val taxiType: DriverType,
+    val taxiModel: String,
+){
+    fun hasNoProblem(){
+        RequestCheckHelper.sayTaxiNumberIsPerfect(this.taxiNumber)
+    }
+}

--- a/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/request/DriverTaxiRegistrationRequest.kt
+++ b/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/request/DriverTaxiRegistrationRequest.kt
@@ -3,7 +3,14 @@ package com.plus.taxiapp.api.taxiDriver.request
 import com.plus.taxiapp.api.taxiDriver.request.policy.RequestCheckHelper
 import com.plus.taxiapp.domain.taxiDriver.DriverType
 
-
+/**
+ * 기사의 택시 정보 등록 API Request
+ * taxiNumber : String - 택시 번호판 번호 (e.g., "서울 28바 2311").
+ * taxiType   : TaxiType - 택시 크기 타입 (e.g., 소형, 중형, 대형).
+ * taxiModel  : String - 택시 차량 모델 (e.g., "미니 쿠퍼", "아반떼").
+ *
+ * @author Choichanhyeok
+ */
 data class DriverTaxiRegistrationRequest (
     val taxiNumber: String,
     val taxiType: DriverType,

--- a/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/request/policy/RequestCheckHelper.kt
+++ b/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/request/policy/RequestCheckHelper.kt
@@ -1,0 +1,11 @@
+package com.plus.taxiapp.api.taxiDriver.request.policy
+
+class RequestCheckHelper private constructor() {
+    companion object {
+        fun sayTaxiNumberIsPerfect(taxiNumber: String) {
+            if (taxiNumber.isBlank()) {
+                throw IllegalArgumentException("택시 번호는 필수입니다.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/response/DriverTaxiRegistrationResponse.kt
+++ b/src/main/kotlin/com/plus/taxiapp/api/taxiDriver/response/DriverTaxiRegistrationResponse.kt
@@ -1,0 +1,31 @@
+package com.plus.taxiapp.api.taxiDriver.response
+
+import com.plus.taxiapp.domain.taxiDriver.Driver
+import com.plus.taxiapp.domain.taxiDriver.DriverType
+
+/**
+ * 기사의 택시 정보 등록 API Response
+ * driverId   : String - 택시기사 id (e.g., "0x0000").
+ * taxiNumber : String - 택시 번호판 번호 (e.g., "서울 28바 2311").
+ * taxiType   : TaxiType - 택시 크기 타입 (e.g., 소형, 중형, 대형).
+ * taxiModel  : String - 택시 차량 모델 (e.g., "미니 쿠퍼", "아반떼").
+ *
+ * @author Choichanhyeok
+ */
+data class DriverTaxiRegistrationResponse (
+    val driverId: String,
+    val taxiNumber: String,
+    val taxiType: DriverType,
+    val taxiModel: String,
+){
+    companion object {
+        fun create(driverInfo: Driver): DriverTaxiRegistrationResponse {
+            return DriverTaxiRegistrationResponse(
+                driverInfo.driverId,
+                driverInfo.taxiNumber,
+                driverInfo.taxiType,
+                driverInfo.taxiModel
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/Driver.kt
+++ b/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/Driver.kt
@@ -1,0 +1,21 @@
+package com.plus.taxiapp.domain.taxiDriver
+
+import com.plus.taxiapp.domain.taxiDriver.command.DriverCommand
+
+data class Driver (
+    val driverId: String,
+    val taxiNumber: String,
+    val taxiType: DriverType,
+    val taxiModel: String,
+) {
+    companion object {
+        fun create(command: DriverCommand.Register): Driver {
+            return Driver(
+                driverId = command.driverId,
+                taxiNumber = command.taxiNumber,
+                taxiType = command.taxiType,
+                taxiModel = command.taxiModel
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverRepository.kt
+++ b/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverRepository.kt
@@ -1,0 +1,5 @@
+package com.plus.taxiapp.domain.taxiDriver
+
+interface DriverRepository {
+    fun saveTaxiInfo(taxi: Driver): Driver
+}

--- a/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverService.kt
+++ b/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverService.kt
@@ -4,10 +4,12 @@ import com.plus.taxiapp.domain.taxiDriver.command.DriverCommand
 import org.springframework.stereotype.Service
 
 @Service
-class DriverService{
+class DriverService(
+    private val driverRepository: DriverRepository,
+) {
     fun taxiInfoRegister(command: DriverCommand.Register): Driver {
 
-        return Driver.create(command)
+        return driverRepository.saveTaxiInfo(Driver.create(command))
     }
 
 }

--- a/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverService.kt
+++ b/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverService.kt
@@ -1,0 +1,13 @@
+package com.plus.taxiapp.domain.taxiDriver
+
+import com.plus.taxiapp.domain.taxiDriver.command.DriverCommand
+import org.springframework.stereotype.Service
+
+@Service
+class DriverService{
+    fun taxiInfoRegister(command: DriverCommand.Register): Driver {
+
+        return Driver.create(command)
+    }
+
+}

--- a/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverType.kt
+++ b/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverType.kt
@@ -1,0 +1,7 @@
+package com.plus.taxiapp.domain.taxiDriver
+
+enum class DriverType(val description: String) {
+    COMPACT("소형"),
+    STANDARD("중형"),
+    LARGE("대형");
+}

--- a/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/command/DriverCommand.kt
+++ b/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/command/DriverCommand.kt
@@ -1,0 +1,28 @@
+package com.plus.taxiapp.domain.taxiDriver.command
+
+import com.plus.taxiapp.domain.taxiDriver.DriverType
+
+class DriverCommand {
+    data class Register(
+        val driverId: String,
+        val taxiNumber: String,
+        val taxiType: DriverType,
+        val taxiModel: String,
+    ) {
+        companion object {
+            fun of(
+                taxiNumber: String,
+                driverId: String,
+                taxiType: DriverType,
+                taxiModel: String,
+            ): Register {
+                return Register(
+                    driverId = driverId,
+                    taxiNumber = taxiNumber,
+                    taxiType = taxiType,
+                    taxiModel = taxiModel,
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/command/DriverCommand.kt
+++ b/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/command/DriverCommand.kt
@@ -1,6 +1,7 @@
 package com.plus.taxiapp.domain.taxiDriver.command
 
 import com.plus.taxiapp.domain.taxiDriver.DriverType
+import com.plus.taxiapp.domain.taxiDriver.command.policy.DriverInfoCheckHelper
 
 class DriverCommand {
     data class Register(
@@ -9,20 +10,9 @@ class DriverCommand {
         val taxiType: DriverType,
         val taxiModel: String,
     ) {
-        companion object {
-            fun of(
-                taxiNumber: String,
-                driverId: String,
-                taxiType: DriverType,
-                taxiModel: String,
-            ): Register {
-                return Register(
-                    driverId = driverId,
-                    taxiNumber = taxiNumber,
-                    taxiType = taxiType,
-                    taxiModel = taxiModel,
-                )
-            }
+        init {
+            DriverInfoCheckHelper.checkTaxiDetailsAreFilled(taxiNumber, taxiModel)
+            DriverInfoCheckHelper.checkTaxiNumberFollowsFormat(taxiNumber)
         }
     }
 }

--- a/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/command/policy/DriverInfoCheckHelper.kt
+++ b/src/main/kotlin/com/plus/taxiapp/domain/taxiDriver/command/policy/DriverInfoCheckHelper.kt
@@ -1,0 +1,20 @@
+package com.plus.taxiapp.domain.taxiDriver.command.policy
+
+
+class DriverInfoCheckHelper {
+    companion object {
+        fun checkTaxiDetailsAreFilled(taxiNumber: String, taxiModel: String) {
+            when {
+                taxiNumber.isBlank() -> throw IllegalArgumentException("Taxi Number is Required")
+                taxiModel.isBlank() -> throw IllegalArgumentException("Taxi Model is Required")
+            }
+        }
+
+        fun checkTaxiNumberFollowsFormat(taxiNumber: String) {
+            val TaxiNumberPattern = """^[가-힣]{2}\s\d{2}[가-힣]{1}\s\d{4}$""".toRegex()
+            when {
+                !TaxiNumberPattern.matches(taxiNumber) -> throw IllegalArgumentException("Taxi Number is not in the right format")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/plus/taxiapp/facade/DriverFacade.kt
+++ b/src/main/kotlin/com/plus/taxiapp/facade/DriverFacade.kt
@@ -1,0 +1,17 @@
+package com.plus.taxiapp.facade
+
+import com.plus.taxiapp.domain.taxiDriver.Driver
+import com.plus.taxiapp.domain.taxiDriver.DriverService
+import com.plus.taxiapp.domain.taxiDriver.command.DriverCommand
+import org.springframework.stereotype.Component
+
+@Component
+class DriverFacade(
+    private val driverService: DriverService,
+    /* private val taxiService: TaxiService,*/ //TODO("택시 서비스 개발 완료시 주입")
+) {
+    fun registerDriverAndTaxi(command: DriverCommand.Register/*, taxi: Taxi*/): Driver {
+        return driverService.taxiInfoRegister(command)
+        // taxiService.registerTaxi(taxi)
+    }
+}

--- a/src/main/kotlin/com/plus/taxiapp/infra/store/taxiDriver/DriverEntity.kt
+++ b/src/main/kotlin/com/plus/taxiapp/infra/store/taxiDriver/DriverEntity.kt
@@ -1,6 +1,7 @@
 package com.plus.taxiapp.infra.store.taxiDriver
 
 import com.plus.taxiapp.domain.taxiDriver.DriverType
+import com.plus.taxiapp.infra.store.base.TimeEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -14,4 +15,4 @@ class DriverEntity (
     val taxiNumber: String,
     val taxiType: DriverType,
     val taxiModel: String,
-)
+): TimeEntity()

--- a/src/main/kotlin/com/plus/taxiapp/infra/store/taxiDriver/DriverEntity.kt
+++ b/src/main/kotlin/com/plus/taxiapp/infra/store/taxiDriver/DriverEntity.kt
@@ -1,0 +1,17 @@
+package com.plus.taxiapp.infra.store.taxiDriver
+
+import com.plus.taxiapp.domain.taxiDriver.DriverType
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+@Entity
+class DriverEntity (
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    val driverId: String,
+    val taxiNumber: String,
+    val taxiType: DriverType,
+    val taxiModel: String,
+)

--- a/src/main/kotlin/com/plus/taxiapp/infra/store/taxiDriver/DriverJpaRepository.kt
+++ b/src/main/kotlin/com/plus/taxiapp/infra/store/taxiDriver/DriverJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.plus.taxiapp.infra.store.taxiDriver
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface DriverJpaRepository: JpaRepository<DriverEntity, Long> {
+
+}

--- a/src/main/kotlin/com/plus/taxiapp/infra/store/taxiDriver/DriverRepositoryImpl.kt
+++ b/src/main/kotlin/com/plus/taxiapp/infra/store/taxiDriver/DriverRepositoryImpl.kt
@@ -1,0 +1,27 @@
+package com.plus.taxiapp.infra.store.taxiDriver
+
+import com.plus.taxiapp.domain.taxiDriver.Driver
+import com.plus.taxiapp.domain.taxiDriver.DriverRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class DriverRepositoryImpl(
+    private val taxiJpaRepository: DriverJpaRepository,
+) : DriverRepository {
+    override fun saveTaxiInfo(taxi: Driver): Driver {
+        val savedTaxi = taxiJpaRepository.save(
+            DriverEntity(
+                taxiNumber = taxi.taxiNumber,
+                driverId = taxi.driverId,
+                taxiType = taxi.taxiType,
+                taxiModel = taxi.taxiModel,
+            )
+        )
+        return Driver(
+            taxi.driverId,
+            taxi.taxiNumber,
+            taxi.taxiType,
+            taxi.taxiModel,
+        )
+    }
+}

--- a/src/test/kotlin/com/plus/taxiapp/api/taxiDriver/DriverApiTest.kt
+++ b/src/test/kotlin/com/plus/taxiapp/api/taxiDriver/DriverApiTest.kt
@@ -6,6 +6,8 @@ import com.plus.taxiapp.domain.taxiDriver.Driver
 import com.plus.taxiapp.domain.taxiDriver.DriverService
 import com.plus.taxiapp.domain.taxiDriver.DriverType
 import com.plus.taxiapp.domain.taxiDriver.command.DriverCommand
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
@@ -30,23 +32,40 @@ class DriverApiTest() {
     @MockBean
     private lateinit var driverService: DriverService
 
-    @Test
-    fun `RegisterTaxi(), 택시기사님은 영업 참여를 위해 택시 정보를 등록한다`() {
-        val taxiInfoRegistRequest = DriverTaxiRegistrationRequest(taxiNumber = "서울 28바 2311", taxiType = DriverType.COMPACT, taxiModel =  "에쿠스")
-        val registedTaxiInfo = Driver("testDriverHyeok", "서울 28바 2311", DriverType.COMPACT, "에쿠스")
+    @Nested
+    @DisplayName("택시정보 등록 성공 테스트")
+    inner class TaxiInfoRegistHttpRequestSuccessTest {
+        @Test
+        fun `RegisterTaxi(), 택시기사님은 영업 참여를 위해 택시 정보를 등록한다`() {
+            val taxiInfoRegistRequest = DriverTaxiRegistrationRequest(
+                taxiNumber = "서울 28바 2311",
+                taxiType = DriverType.COMPACT,
+                taxiModel = "에쿠스"
+            )
+            val registedTaxiInfo = Driver("testDriverHyeok", "서울 28바 2311", DriverType.COMPACT, "에쿠스")
 
-        given(driverService.taxiInfoRegister(DriverCommand.Register("testDriverHyeok", "서울 28바 2311", DriverType.COMPACT, "에쿠스"))).willReturn(registedTaxiInfo)
+            given(
+                driverService.taxiInfoRegister(
+                    DriverCommand.Register(
+                        "testDriverHyeok",
+                        "서울 28바 2311",
+                        DriverType.COMPACT,
+                        "에쿠스"
+                    )
+                )
+            ).willReturn(registedTaxiInfo)
 
-        mockMvc.perform(
-            MockMvcRequestBuilders.post("/api/drivers/testDriverHyeok/taxis")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(taxiInfoRegistRequest))
-        )
-            .andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(MockMvcResultMatchers.jsonPath("$.driverId").value("testDriverHyeok"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.taxiNumber").value("서울 28바 2311"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.taxiType").value("COMPACT"))
-            .andExpect(MockMvcResultMatchers.jsonPath("$.taxiModel").value("에쿠스"))
-            .andDo(MockMvcResultHandlers.print())
+            mockMvc.perform(
+                MockMvcRequestBuilders.post("/api/drivers/testDriverHyeok/taxis")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(taxiInfoRegistRequest))
+            )
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andExpect(MockMvcResultMatchers.jsonPath("$.driverId").value("testDriverHyeok"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.taxiNumber").value("서울 28바 2311"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.taxiType").value("COMPACT"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.taxiModel").value("에쿠스"))
+                .andDo(MockMvcResultHandlers.print())
+        }
     }
 }

--- a/src/test/kotlin/com/plus/taxiapp/api/taxiDriver/DriverApiTest.kt
+++ b/src/test/kotlin/com/plus/taxiapp/api/taxiDriver/DriverApiTest.kt
@@ -1,0 +1,52 @@
+package com.plus.taxiapp.api.taxiDriver
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.plus.taxiapp.api.taxiDriver.request.DriverTaxiRegistrationRequest
+import com.plus.taxiapp.domain.taxiDriver.Driver
+import com.plus.taxiapp.domain.taxiDriver.DriverService
+import com.plus.taxiapp.domain.taxiDriver.DriverType
+import com.plus.taxiapp.domain.taxiDriver.command.DriverCommand
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+@WebMvcTest(DriverApi::class)
+@AutoConfigureMockMvc
+class DriverApiTest() {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @MockBean
+    private lateinit var driverService: DriverService
+
+    @Test
+    fun `RegisterTaxi(), 택시기사님은 영업 참여를 위해 택시 정보를 등록한다`() {
+        val taxiInfoRegistRequest = DriverTaxiRegistrationRequest(taxiNumber = "서울 28바 2311", taxiType = DriverType.COMPACT, taxiModel =  "에쿠스")
+        val registedTaxiInfo = Driver("testDriverHyeok", "서울 28바 2311", DriverType.COMPACT, "에쿠스")
+
+        given(driverService.taxiInfoRegister(DriverCommand.Register("testDriverHyeok", "서울 28바 2311", DriverType.COMPACT, "에쿠스"))).willReturn(registedTaxiInfo)
+
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/api/drivers/testDriverHyeok/taxis")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(taxiInfoRegistRequest))
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.driverId").value("testDriverHyeok"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.taxiNumber").value("서울 28바 2311"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.taxiType").value("COMPACT"))
+            .andExpect(MockMvcResultMatchers.jsonPath("$.taxiModel").value("에쿠스"))
+            .andDo(MockMvcResultHandlers.print())
+    }
+}

--- a/src/test/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverServiceTest.kt
+++ b/src/test/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverServiceTest.kt
@@ -1,0 +1,52 @@
+package com.plus.taxiapp.domain.taxiDriver
+
+import com.plus.taxiapp.domain.taxiDriver.command.DriverCommand
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+
+@SpringBootTest
+@ExtendWith(MockitoExtension::class)
+@DisplayName("택시정보 등록 테스트")
+internal class DriverServiceTest {
+
+    @Autowired
+    private lateinit var driverService: DriverService
+
+    @MockBean
+    private lateinit var driverRepository: DriverRepository
+
+
+    @Nested
+    @DisplayName("택시정보 등록 성공 테스트")
+    inner class TaxiInfoRegistSuccess {
+
+        @Test
+        fun `taxiInfoRegister() - 택시 정보가 올바르게 등록된다`() {
+            val command = DriverCommand.Register(
+                driverId = "testDriverHyeok",
+                taxiNumber = "서울 28바 2311",
+                taxiType = DriverType.COMPACT,
+                taxiModel = "에쿠스"
+            )
+            val taxiInfo = Driver("testDriverHyeok", "서울 28바 2311", DriverType.COMPACT, "에쿠스")
+
+            given(driverRepository.saveTaxiInfo(taxiInfo)).willReturn(taxiInfo)
+
+            val result = driverService.taxiInfoRegister(command)
+
+            assertThat(result.driverId).isEqualTo(taxiInfo.driverId)
+            assertThat(result.taxiNumber).isEqualTo(taxiInfo.taxiNumber)
+            assertThat(result.taxiType).isEqualTo(taxiInfo.taxiType)
+            assertThat(result.taxiModel).isEqualTo(taxiInfo.taxiModel)
+        }
+    }
+}

--- a/src/test/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverServiceTest.kt
+++ b/src/test/kotlin/com/plus/taxiapp/domain/taxiDriver/DriverServiceTest.kt
@@ -6,24 +6,15 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.BDDMockito.given
-import org.mockito.junit.jupiter.MockitoExtension
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 
 @SpringBootTest
-@ExtendWith(MockitoExtension::class)
 @DisplayName("택시정보 등록 테스트")
 internal class DriverServiceTest {
 
     @Autowired
     private lateinit var driverService: DriverService
-
-    @MockBean
-    private lateinit var driverRepository: DriverRepository
-
 
     @Nested
     @DisplayName("택시정보 등록 성공 테스트")
@@ -38,8 +29,6 @@ internal class DriverServiceTest {
                 taxiModel = "에쿠스"
             )
             val taxiInfo = Driver("testDriverHyeok", "서울 28바 2311", DriverType.COMPACT, "에쿠스")
-
-            given(driverRepository.saveTaxiInfo(taxiInfo)).willReturn(taxiInfo)
 
             val result = driverService.taxiInfoRegister(command)
 

--- a/src/test/kotlin/com/plus/taxiapp/domain/taxiDriver/command/DriverCommandTest.kt
+++ b/src/test/kotlin/com/plus/taxiapp/domain/taxiDriver/command/DriverCommandTest.kt
@@ -1,0 +1,43 @@
+package com.plus.taxiapp.domain.taxiDriver.command
+
+import com.plus.taxiapp.domain.taxiDriver.DriverType
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("DriverCommand 테스트")
+internal class DriverCommandTest {
+
+    @Nested
+    @DisplayName("택시 정보 Regist 성공 테스트")
+    inner class ValidateTaxiInfoSuccess {
+
+        @Test
+        fun `정책에 맞는 택시 정보가 입력되면 에러가 발생하지 않는다`() {
+            DriverCommand.Register(
+                driverId = "testDriverHyeok",
+                taxiNumber = "서울 28바 2311",
+                taxiType = DriverType.COMPACT,
+                taxiModel = "에쿠스"
+            )
+        }
+    }
+
+    @Nested
+    @DisplayName("택시 정보 Regist 실패 테스트")
+    inner class ValidateTaxiInfoFailure {
+        @Test
+        fun `잘못된 생성자 인자값이 들어가면 택시정보 등록을 할 수 없다`() {
+            assertThrows<IllegalArgumentException> {
+                DriverCommand.Register(
+                    driverId = "testDriverHyeok",
+                    taxiNumber = "",
+                    taxiType = DriverType.COMPACT,
+                    taxiModel = "에쿠스"
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/plus/taxiapp/domain/taxiDriver/command/policy/DriverInfoCheckHelperTest.kt
+++ b/src/test/kotlin/com/plus/taxiapp/domain/taxiDriver/command/policy/DriverInfoCheckHelperTest.kt
@@ -1,0 +1,66 @@
+package com.plus.taxiapp.domain.taxiDriver.command.policy
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class DriverInfoCheckHelperTest {
+
+    @Nested
+    @DisplayName("택시 정보 검증 성공 테스트")
+    inner class ValidateTaxiInfoSuccess {
+
+        @Test
+        fun `정책에 맞는 택시 정보가 입력되면 에러가 발생하지 않는다`() {
+            DriverInfoCheckHelper.checkTaxiDetailsAreFilled("서울 28바 2311", "에쿠스")
+            DriverInfoCheckHelper.checkTaxiNumberFollowsFormat("서울 28바 2311")
+        }
+    }
+
+    @Nested
+    @DisplayName("택시 정보 검증 실패 테스트")
+    inner class ValidateTaxiInfoFailure {
+
+        @Test
+        fun `택시 번호가 비어있으면 예외가 발생한다`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                DriverInfoCheckHelper.checkTaxiDetailsAreFilled("", "에쿠스")
+            }
+            assertEquals("Taxi Number is Required", exception.message)
+        }
+
+        @Test
+        fun `택시 번호가 공백으로 이루어져있는 경우 예외가 발생한다`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                DriverInfoCheckHelper.checkTaxiDetailsAreFilled(" ", "에쿠스")
+            }
+            assertEquals("Taxi Number is Required", exception.message)
+        }
+
+        @Test
+        fun `택시 모델이 비어있으면 예외가 발생한다`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                DriverInfoCheckHelper.checkTaxiDetailsAreFilled("서울 28바 2311", "")
+            }
+            assertEquals("Taxi Model is Required", exception.message)
+        }
+
+        @Test
+        fun `택시 모델이 공백으로 이루어져 있는 경우 예외가 발생한다`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                DriverInfoCheckHelper.checkTaxiDetailsAreFilled("서울 28바 2311", "")
+            }
+            assertEquals("Taxi Model is Required", exception.message)
+        }
+
+        @Test
+        fun `택시 번호 형식이 올바르지 않으면 예외가 발생한다`() {
+            val exception = assertThrows<IllegalArgumentException> {
+                DriverInfoCheckHelper.checkTaxiNumberFollowsFormat("서울28바2311")
+            }
+            assertEquals("Taxi Number is not in the right format", exception.message)
+        }
+    }
+}


### PR DESCRIPTION
## 기사님의 택시 정보 등록
> (1) 택시 정보 등록을 위한 api, service, repository 및 테스트 코드 작성
>
> (2) #4 에서 추가된 BaseEntity Driver Entity에 적용

<br>

### [특이사항]

#### 1. 컨벤션 미준수 사항 발생
  - paymentCommand 등의 클래스에서 생성자 초기화시 when으로 예외 처리를 하는 부분이 있는데 이를 별도 클래스로 분리해 작업키위해
     해당 컨벤션 미준수

```
# 기존 컨벤션
            when {
                memberId == null -> throw IllegalArgumentException("Member ID is Required")
                accountNum.isBlank() -> throw IllegalArgumentException("Account Number is Required")
                accountPassword.isBlank() -> throw IllegalArgumentException("Account Password is Required")
           ..
```
```
# 미준수 대상
        init {
            DriverInfoCheckHelper.checkTaxiDetailsAreFilled(taxiNumber, taxiModel)
            DriverInfoCheckHelper.checkTaxiNumberFollowsFormat(taxiNumber)
        }
    }
```