### PR TITLE
Feature/apply mdc

### DIFF
--- a/src/main/kotlin/com/plus/taxiapp/shared/aop/advice/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/plus/taxiapp/shared/aop/advice/GlobalExceptionHandler.kt
@@ -12,7 +12,6 @@ class GlobalExceptionHandler {
     @ExceptionHandler(Exception::class)
     fun handleAllExceptions(ex: Exception): ResponseEntity<ErrorResponse> {
         val errorResponse = ErrorResponse("Exception000", ex.message ?: "An error occurred.")
-        //log.error("Exception: ", ex)
         return ResponseEntity.internalServerError().body(errorResponse)
     }
 }

--- a/src/main/kotlin/com/plus/taxiapp/shared/aop/aspect/LoggingAspect.kt
+++ b/src/main/kotlin/com/plus/taxiapp/shared/aop/aspect/LoggingAspect.kt
@@ -12,17 +12,13 @@ import org.springframework.stereotype.Component
 @Component
 @Slf4j
 class LoggingAspect {
+
     @Before("execution(* com.plus.taxiapp..*.*(..))")
     fun beforeMethodCall(joinPoint: JoinPoint) {
         val methodName = joinPoint.signature.name
         val args = joinPoint.args.joinToString(", ") // 모든 인자를 문자열로 변환
 
-        val threadId = Thread.currentThread().id
-        val timestamp = System.currentTimeMillis()
-        val instanceId = "[미정]"
-
-        val traceId = "$instanceId-$timestamp-$threadId"
-        log.info("[$traceId] [${System.currentTimeMillis()}] [$methodName] called with args: $args")
+        log.info("[$methodName] called with args: $args")
     }
 
     @AfterReturning(pointcut = "execution(* com.plus.taxiapp..*.*(..))", returning = "result")
@@ -30,12 +26,7 @@ class LoggingAspect {
         val methodName = joinPoint.signature.name
         val args = joinPoint.args.joinToString(", ")
 
-        val threadId = Thread.currentThread().id
-        val timestamp = System.currentTimeMillis()
-        val instanceId = "[미정]"
-
-        val traceId = "$instanceId-$timestamp-$threadId"
-        log.info("[$traceId] [${System.currentTimeMillis()}] [$methodName] called with args: $args, returned: $result")
+        log.info("[$methodName] called with args: $args, returned: $result")
     }
 
 }

--- a/src/main/kotlin/com/plus/taxiapp/shared/config/FilterConfig.kt
+++ b/src/main/kotlin/com/plus/taxiapp/shared/config/FilterConfig.kt
@@ -1,0 +1,20 @@
+package com.plus.taxiapp.shared.config
+
+import com.plus.taxiapp.shared.filter.TraceIdFilter
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class FilterConfig {
+
+    @Bean
+    fun traceIdFilterRegistration(filter: TraceIdFilter): FilterRegistrationBean<*> {
+        val registration = FilterRegistrationBean<TraceIdFilter>()
+        registration.filter = filter
+        registration.addUrlPatterns("/*")
+        registration.setName("traceIdFilter")
+        registration.order = 1
+        return registration
+    }
+}

--- a/src/main/kotlin/com/plus/taxiapp/shared/filter/TraceIdFilter.kt
+++ b/src/main/kotlin/com/plus/taxiapp/shared/filter/TraceIdFilter.kt
@@ -1,0 +1,43 @@
+package com.plus.taxiapp.shared.filter
+
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+import java.util.*
+
+@Component
+class TraceIdFilter : Filter {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(TraceIdFilter::class.java)
+    }
+
+    override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+        val traceId = UUID.randomUUID().toString()
+        MDC.put("traceId", traceId)
+
+        if (isHttp(request, response)) {
+            val httpRequest = request as HttpServletRequest
+            val httpResponse = response as HttpServletResponse
+
+            log.info("REQUEST TRACING_ID: {}, Method: {}, URI: {}", traceId, httpRequest.method, httpRequest.requestURI)
+            chain.doFilter(request, response)
+            System.out.println("##### TraceIdFilter is called!")
+            log.info("RESPONSE TRACING_ID: {}, Status: {}", traceId, httpResponse.status)
+        } else {
+            chain.doFilter(request, response)
+        }
+
+        MDC.clear()
+    }
+
+    private fun isHttp(request: ServletRequest, response: ServletResponse): Boolean {
+        return request is HttpServletRequest && response is HttpServletResponse
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%X{traceId}]: %d{yyyy-MM-dd HH:mm:ss}: %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="PROD" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>log/taxiapp/taxiapp_%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>2</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>[%X{traceId}]: %d{yyyy-MM-dd HH:mm:ss}: %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="DEV" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>log/taxiapp/taxiapp_%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxFileSize>100MB</maxFileSize>
+            <maxHistory>2</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>[%X{traceId}]: %d{yyyy-MM-dd HH:mm:ss}: %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <springProfile name="default">
+        <root level="DEBUG">
+            <appender-ref ref="STDOUT" />
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <root level="DEBUG">
+            <appender-ref ref="DEV"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="PROD" />
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
### 로그 주체 식별을 위한 tracing id 적용

- mdc에서 제공하는 쓰레드 로컬을 이용해 filter에 request가 들어올 때 쓰레드 식별을 위한 tracing_id 을 uuid로 생성
- slf4j에서 제공하는 logback-spring.xml에 설정을 통해 모든 로그에 쓰레드 식별을 위한 tracing_id와 시간값 기록토록
- 기존 method 호출시 인자값 추적을 위해 테스트용으로 작성한 aspect 로거에 시간 값, tracing_id를 제거